### PR TITLE
Fix incorrect hook name when removing

### DIFF
--- a/lua/mkeyboard/client/interface.lua
+++ b/lua/mkeyboard/client/interface.lua
@@ -153,7 +153,7 @@ function MKeyboard:Shutdown()
     hook.Remove( "PlayerButtonDown", "MKeyboard.DetectButtonPress" )
     hook.Remove( "PlayerButtonUp", "MKeyboard.DetectButtonRelease" )
     hook.Remove( "PlayerBindPress", "MKeyboard.BlockBinds" )
-    hook.Remove( "BlockChatInput", "MKeyboard.PreventOpeningChat" )
+    hook.Remove( "CustomChatBlockInput", "MKeyboard.PreventOpeningChat" )
 end
 
 local settings = MKeyboard.settings


### PR DESCRIPTION
Fixes a bug on servers with the Custom Chat addon which makes you unable to open the chat or esc menu after using the keyboard. The hook is "CustomChatBlockInput" but it tries to remove "ChatBlockInput"