### PR TITLE
Use localized category name

### DIFF
--- a/lua/entities/ent_musical_keyboard/shared.lua
+++ b/lua/entities/ent_musical_keyboard/shared.lua
@@ -7,6 +7,6 @@ ENT.Contact = "StyledStrike#8032"
 ENT.Purpose = "Replacement for Playable Piano, with improvements"
 ENT.Instructions = "Press E to use the instrument, use the keyboard or a MIDI device (if available) to play."
 
-ENT.Category = "Fun + Games"
+ENT.Category = "#spawnmenu.category.fun_games"
 ENT.Spawnable = true
 ENT.AdminOnly = false


### PR DESCRIPTION
Will cause a split in the Fun + Games category if the language is not set to English